### PR TITLE
Bugfix: Register correct object in jersey for Jedis

### DIFF
--- a/dropwizard-redis/src/main/java/com/bendb/dropwizard/redis/JedisBundle.java
+++ b/dropwizard-redis/src/main/java/com/bendb/dropwizard/redis/JedisBundle.java
@@ -1,6 +1,6 @@
 package com.bendb.dropwizard.redis;
 
-import com.bendb.dropwizard.redis.jersey.JedisFactory;
+import com.bendb.dropwizard.redis.jersey.JedisPoolBinder;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;
@@ -24,6 +24,6 @@ public abstract class JedisBundle<C extends Configuration>
         pool = getJedisFactory(configuration).build(environment);
 
         environment.healthChecks().register("redis", new JedisHealthCheck(pool));
-        environment.jersey().register(new JedisFactory(pool));
+        environment.jersey().register(new JedisPoolBinder(pool));
     }
 }


### PR DESCRIPTION
Fix for ```NullPointerException``` when trying to call ```Jedis``` object  from ```@Context```

````
ERROR [2015-03-09 14:58:14,620] io.dropwizard.jersey.errors.LoggingExceptionMapper: Error handling a request: 4131b7f739827406
! java.lang.NullPointerException: null 
````