### PR TITLE
Support multiple datasources

### DIFF
--- a/droptools-example/config/dev.yml
+++ b/droptools-example/config/dev.yml
@@ -24,11 +24,17 @@ logging:
     - type: console
       target: stdout
 
-database:
+databaseMaster:
   driverClass: org.postgresql.Driver
   user: example_user
   password: s3cr3t
-  url: jdbc:postgresql://localhost:5432/example_app
+  url: jdbc:postgresql://localhost:5432/example_app1
+
+databaseSlave:
+  driverClass: org.postgresql.Driver
+  user: example_user
+  password: s3cr3t
+  url: jdbc:postgresql://localhost:5432/example_app2
 
 flyway:
   # The default prefix is 'V', but I prefer no prefix at all.

--- a/droptools-example/src/main/java/com/bendb/example/ExampleApp.java
+++ b/droptools-example/src/main/java/com/bendb/example/ExampleApp.java
@@ -33,13 +33,32 @@ public class ExampleApp extends Application<ExampleConfig> {
 
         bootstrap.addBundle(new JooqBundle<ExampleConfig>() {
 
+            /**
+             * Required override to define default DataSourceFactory.
+             */
             @Override
-            public SortedMap<String,DataSourceFactory> getDataSourceFactories(ExampleConfig configuration) {
+            public DataSourceFactory getDataSourceFactory(ExampleConfig configuration) {
+                return configuration.dataSourceFactoryMaster();
+            }
+
+            /**
+             * Optional override to define secondary DataSourceFactories.
+             */
+            @Override
+            public SortedMap<String,DataSourceFactory> getSecondaryDataSourceFactories(ExampleConfig configuration) {
                 // override this method to define database configurations
                 final SortedMap<String,DataSourceFactory> dataSourceFactoryMap = new TreeMap<>();
-                dataSourceFactoryMap.put("master", configuration.dataSourceFactoryMaster());
                 dataSourceFactoryMap.put("slave", configuration.dataSourceFactorySlave());
                 return dataSourceFactoryMap;
+            }
+
+            /**
+             * Optional override to define reference name of the default DataSourceFactory.
+             * Defaults to "jooq".
+             */
+            @Override
+            public String primaryDataSourceName() {
+                return "master";
             }
 
             @Override

--- a/droptools-example/src/main/java/com/bendb/example/ExampleApp.java
+++ b/droptools-example/src/main/java/com/bendb/example/ExampleApp.java
@@ -9,6 +9,8 @@ import io.dropwizard.flyway.FlywayBundle;
 import io.dropwizard.flyway.FlywayFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 public class ExampleApp extends Application<ExampleConfig> {
     public static void main(String[] args) throws Exception {
@@ -20,7 +22,7 @@ public class ExampleApp extends Application<ExampleConfig> {
         bootstrap.addBundle(new FlywayBundle<ExampleConfig>() {
             @Override
             public DataSourceFactory getDataSourceFactory(ExampleConfig configuration) {
-                return configuration.dataSourceFactory();
+                return configuration.dataSourceFactoryMaster();
             }
 
             @Override
@@ -30,9 +32,14 @@ public class ExampleApp extends Application<ExampleConfig> {
         });
 
         bootstrap.addBundle(new JooqBundle<ExampleConfig>() {
+
             @Override
-            public DataSourceFactory getDataSourceFactory(ExampleConfig configuration) {
-                return configuration.dataSourceFactory();
+            public SortedMap<String,DataSourceFactory> getDataSourceFactories(ExampleConfig configuration) {
+                // override this method to define database configurations
+                final SortedMap<String,DataSourceFactory> dataSourceFactoryMap = new TreeMap<>();
+                dataSourceFactoryMap.put("master", configuration.dataSourceFactoryMaster());
+                dataSourceFactoryMap.put("slave", configuration.dataSourceFactorySlave());
+                return dataSourceFactoryMap;
             }
 
             @Override

--- a/droptools-example/src/main/java/com/bendb/example/ExampleConfig.java
+++ b/droptools-example/src/main/java/com/bendb/example/ExampleConfig.java
@@ -19,7 +19,11 @@ public class ExampleConfig extends Configuration {
 
     @JsonProperty
     @NotNull
-    private DataSourceFactory database;
+    private DataSourceFactory databaseMaster;
+
+    @JsonProperty
+    @NotNull
+    private DataSourceFactory databaseSlave;
 
     public FlywayFactory flyway() {
         return flyway;
@@ -29,7 +33,11 @@ public class ExampleConfig extends Configuration {
         return jooq;
     }
 
-    public DataSourceFactory dataSourceFactory() {
-        return database;
+    public DataSourceFactory dataSourceFactoryMaster() {
+        return databaseMaster;
+    }
+
+    public DataSourceFactory dataSourceFactorySlave() {
+        return databaseSlave;
     }
 }

--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/JooqBundle.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/JooqBundle.java
@@ -7,10 +7,16 @@ import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.jooq.Configuration;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 public abstract class JooqBundle<C extends io.dropwizard.Configuration>
         implements ConfiguredBundle<C>, JooqConfiguration<C> {
-    private Configuration configuration;
+
+    private static final String DEFAULT_NAME = "jooq";
+
+    private final SortedMap<String,Configuration> jooqFactoryConfigurationMap = new TreeMap<>();
 
     public void initialize(Bootstrap<?> bootstrap) {
         // No bootstrap-phase action required.
@@ -18,25 +24,60 @@ public abstract class JooqBundle<C extends io.dropwizard.Configuration>
 
     @Override
     public void run(C configuration, Environment environment) throws Exception {
-        final DataSourceFactory dataSourceFactory = getDataSourceFactory(configuration);
-        final JooqFactory jooqFactory = getJooqFactory(configuration);
-        final Configuration cfg = jooqFactory.build(environment, dataSourceFactory);
-        final JooqHealthCheck healthCheck = new JooqHealthCheck(cfg, dataSourceFactory.getValidationQuery());
+        final SortedMap<String,DataSourceFactory> dataSourceFactoryMap = getDataSourceFactories(configuration);
 
-        environment.healthChecks().register("jooq", healthCheck);
-        environment.jersey().register(new JooqBinder(cfg));
+        for (final Map.Entry<String,DataSourceFactory> dataSourceFactoryEntry : dataSourceFactoryMap.entrySet()) {
+            final String name = dataSourceFactoryEntry.getKey();
+            final DataSourceFactory dataSourceFactory = dataSourceFactoryEntry.getValue();
+
+            final JooqFactory jooqFactory = getJooqFactory(configuration);
+            final Configuration cfg = jooqFactory.build(environment, dataSourceFactory, name);
+            final JooqHealthCheck healthCheck = new JooqHealthCheck(cfg, dataSourceFactory.getValidationQuery());
+
+            environment.healthChecks().register(name, healthCheck);
+
+            jooqFactoryConfigurationMap.put(name, cfg);
+        }
+
+        environment.jersey().register(new JooqBinder(jooqFactoryConfigurationMap));
         environment.jersey().register(new LoggingDataAccessExceptionMapper());
-
-        this.configuration = cfg;
     }
 
+    /**
+     * Override this method to use a non-default jOOQ configuration.
+     */
     @Override
     public JooqFactory getJooqFactory(C configuration) {
-        // Override this method to use a non-default jOOQ configuration.
         return new JooqFactory();
     }
 
+    /**
+     * Override this method to use a single database.
+     * Deprecated: use getDataSourceFactories instead.
+     */
+    @Deprecated
+    @Override
+    public DataSourceFactory getDataSourceFactory(C configuration) {
+        return null;
+    }
+
+    /**
+     * Override this method to use multiple databases, with instances referenced by name.
+     */
+    @Override
+    public SortedMap<String,DataSourceFactory> getDataSourceFactories(C configuration) {
+        final SortedMap<String,DataSourceFactory> dataSourceFactoryMap = new TreeMap<>();
+
+        // calls deprecated method to ensure backwards compatibility
+        dataSourceFactoryMap.put(DEFAULT_NAME, getDataSourceFactory(configuration));
+        return dataSourceFactoryMap;
+    }
+
     public Configuration getConfiguration() {
-        return configuration;
+        return jooqFactoryConfigurationMap.values().stream().findFirst().orElse(null);
+    }
+
+    public Map<String,Configuration> getConfigurationMap() {
+        return jooqFactoryConfigurationMap;
     }
 }

--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/JooqConfiguration.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/JooqConfiguration.java
@@ -3,6 +3,7 @@ package com.bendb.dropwizard.jooq;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DatabaseConfiguration;
 
-public interface JooqConfiguration<C extends Configuration> extends DatabaseConfiguration<C> {
+public interface JooqConfiguration<C extends Configuration> extends DatabaseConfiguration<C>,
+                                                                    MultiDatabaseConfiguration<C> {
     JooqFactory getJooqFactory(C configuration);
 }

--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/JooqConfiguration.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/JooqConfiguration.java
@@ -1,9 +1,21 @@
 package com.bendb.dropwizard.jooq;
 
+import com.google.common.collect.ImmutableSortedMap;
 import io.dropwizard.Configuration;
+import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.DatabaseConfiguration;
+
+import java.util.SortedMap;
 
 public interface JooqConfiguration<C extends Configuration> extends DatabaseConfiguration<C>,
                                                                     MultiDatabaseConfiguration<C> {
+
     JooqFactory getJooqFactory(C configuration);
+
+    /**
+     * Override this method to use multiple databases, with instances referenced by name.
+     */
+    default SortedMap<String,DataSourceFactory> getSecondaryDataSourceFactories(C configuration) {
+        return ImmutableSortedMap.of();
+    }
 }

--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/JooqFactory.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/JooqFactory.java
@@ -113,6 +113,8 @@ import javax.validation.constraints.NotNull;
  * </table>
  */
 public class JooqFactory {
+    private static final String DEFAULT_NAME = "jooq";
+
     @NotNull
     private Optional<SQLDialect> dialect = Optional.absent();
 
@@ -249,9 +251,13 @@ public class JooqFactory {
     }
 
     public Configuration build(Environment environment, DataSourceFactory factory) throws ClassNotFoundException {
+        return build(environment, factory, DEFAULT_NAME);
+    }
+
+    public Configuration build(Environment environment, DataSourceFactory factory, String name) throws ClassNotFoundException {
         final Settings settings = buildSettings();
         final SQLDialect dialect = determineDialect(factory);
-        final ManagedDataSource dataSource = factory.build(environment.metrics(), "jooq");
+        final ManagedDataSource dataSource = factory.build(environment.metrics(), name);
         final ConnectionProvider connectionProvider = new DataSourceConnectionProvider(dataSource);
         final Configuration config = new DefaultConfiguration();
         config.set(settings);

--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/MultiDatabaseConfiguration.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/MultiDatabaseConfiguration.java
@@ -12,5 +12,5 @@ public interface MultiDatabaseConfiguration<T extends Configuration> {
      * @param configuration a Configuration
      * @return a SortedMap containing DataSourceFactories, with the key being a String name.
      */
-    SortedMap<String,DataSourceFactory> getDataSourceFactories(T configuration);
+    SortedMap<String,DataSourceFactory> getSecondaryDataSourceFactories(T configuration);
 }

--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/MultiDatabaseConfiguration.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/MultiDatabaseConfiguration.java
@@ -1,0 +1,16 @@
+package com.bendb.dropwizard.jooq;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.db.DataSourceFactory;
+import java.util.SortedMap;
+
+public interface MultiDatabaseConfiguration<T extends Configuration> {
+
+    /**
+     * Override to add multiple data source factories to the bundle, each distinguished by a unique name.
+     *
+     * @param configuration a Configuration
+     * @return a SortedMap containing DataSourceFactories, with the key being a String name.
+     */
+    SortedMap<String,DataSourceFactory> getDataSourceFactories(T configuration);
+}

--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/jersey/DSLContextValueFactoryProvider.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/jersey/DSLContextValueFactoryProvider.java
@@ -1,0 +1,44 @@
+package com.bendb.dropwizard.jooq.jersey;
+
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.jersey.server.model.Parameter;
+import org.glassfish.jersey.server.spi.internal.ValueFactoryProvider;
+import org.jooq.Configuration;
+import org.jooq.DSLContext;
+import javax.inject.Singleton;
+import java.util.Map;
+
+@Singleton
+public final class DSLContextValueFactoryProvider implements ValueFactoryProvider {
+
+    final Map<String, Configuration> configurationMap;
+
+    public DSLContextValueFactoryProvider(Map<String, Configuration> configurationMap) {
+        this.configurationMap = configurationMap;
+    }
+
+    @Override
+    public Factory<?> getValueFactory(Parameter parameter) {
+        final Class<?> classType = parameter.getRawType();
+        final JooqInject jooqInjectParam = parameter.getAnnotation(JooqInject.class);
+
+        return (classType == null || !classType.equals(DSLContext.class) || jooqInjectParam == null)
+               ? null // return null when parameter not supported
+               : new DSLContextFactory(getConfiguration(configurationMap, jooqInjectParam.value())
+               );
+    }
+
+    @Override
+    public PriorityType getPriority() {
+        return ValueFactoryProvider.Priority.NORMAL;
+    }
+
+    private Configuration getConfiguration(
+            final Map<String, Configuration> configurationMap,
+            final String key
+    ) {
+        return (configurationMap.containsKey(key))
+               ? configurationMap.get(key)
+               : configurationMap.values().stream().findFirst().orElse(null);
+    }
+}

--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/jersey/JooqInject.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/jersey/JooqInject.java
@@ -1,0 +1,10 @@
+package com.bendb.dropwizard.jooq.jersey;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface JooqInject {
+    String value() default "";
+}

--- a/dropwizard-jooq/src/test/java/com/bendb/dropwizard/jooq/JooqBundleTest.java
+++ b/dropwizard-jooq/src/test/java/com/bendb/dropwizard/jooq/JooqBundleTest.java
@@ -59,15 +59,19 @@ public class JooqBundleTest {
 
         @Override
         public DataSourceFactory getDataSourceFactory(DropwizardConfig configuration) {
-            return null;
+            return dataSourceFactoryMaster;
         }
 
         @Override
-        public SortedMap<String,DataSourceFactory> getDataSourceFactories(DropwizardConfig configuration) {
+        public SortedMap<String,DataSourceFactory> getSecondaryDataSourceFactories(DropwizardConfig configuration) {
             final SortedMap<String,DataSourceFactory> dataSourceFactoryMap = new TreeMap<>();
-            dataSourceFactoryMap.put(DATASOURCE_MASTER, dataSourceFactoryMaster);
             dataSourceFactoryMap.put(DATASOURCE_SLAVE, dataSourceFactorySlave);
             return dataSourceFactoryMap;
+        }
+
+        @Override
+        public String primaryDataSourceName() {
+            return DATASOURCE_MASTER;
         }
     };
 

--- a/dropwizard-jooq/src/test/java/com/bendb/dropwizard/jooq/JooqFactoryTest.java
+++ b/dropwizard-jooq/src/test/java/com/bendb/dropwizard/jooq/JooqFactoryTest.java
@@ -28,6 +28,7 @@ public class JooqFactoryTest {
     @Mock ManagedDataSource managedDataSource;
     @Mock Environment environment;
     @Mock LifecycleEnvironment lifecycle;
+    final static String DATASOURCE_NAME = "database";
 
     private JooqFactory factory;
 
@@ -43,6 +44,13 @@ public class JooqFactoryTest {
     @Test
     public void buildsConfigurationUsingDataSourceFactory() throws Exception {
         Configuration config = factory.build(environment, dataSourceFactory);
+        DataSourceConnectionProvider provider = (DataSourceConnectionProvider) config.connectionProvider();
+        assertThat(provider.dataSource()).is(managedDataSource);
+    }
+
+    @Test
+    public void buildsConfigurationUsingDataSourceFactoryAndName() throws Exception {
+        Configuration config = factory.build(environment, dataSourceFactory, DATASOURCE_NAME);
         DataSourceConnectionProvider provider = (DataSourceConnectionProvider) config.connectionProvider();
         assertThat(provider.dataSource()).is(managedDataSource);
     }
@@ -95,4 +103,5 @@ public class JooqFactoryTest {
         ExecuteListenerProvider[] providers = config.executeListenerProviders();
         assertThat(providers.length).isEqualTo(0);
     }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -180,8 +180,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <fork>true</fork>
                 </configuration>
             </plugin>


### PR DESCRIPTION
- added a @JooqInject annotation to reference multiple datasources
- updated ExampleApp and PostResource to use new annotation
- added unit tests
- supports backwards compatibility
- requires jdk8 for streams API