### PR TITLE
Bump Jedis to 2.8.0

### DIFF
--- a/dropwizard-redis/pom.xml
+++ b/dropwizard-redis/pom.xml
@@ -19,7 +19,7 @@
     <description>Addon bundle for Dropwizard to support use of Redis</description>
 
     <properties>
-        <jedis.version>2.6.0</jedis.version>
+        <jedis.version>2.8.0</jedis.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
None of the changes between 2.6 and 2.8 break our integration; this is an easy upgrade.

Fixes #16