### PR TITLE
Configure Jedis via URL

### DIFF
--- a/dropwizard-redis/src/main/java/com/bendb/dropwizard/redis/JedisFactory.java
+++ b/dropwizard-redis/src/main/java/com/bendb/dropwizard/redis/JedisFactory.java
@@ -8,6 +8,7 @@ import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.Protocol;
 
 import javax.validation.constraints.NotNull;
+import java.net.URL;
 
 /**
  * A factory for creating configured {@link JedisPool} instances.
@@ -69,6 +70,16 @@ public class JedisFactory {
 
     @JsonProperty
     private int maxTotal = DEFAULT_MAX_TOTAL;
+
+    @JsonProperty
+    public void setUrl(URL url) {
+        this.endpoint = HostAndPort.fromParts(url.getHost(), url.getPort());
+        String userInfo = url.getUserInfo();
+        if (userInfo != null && !userInfo.isEmpty()) {
+            String[] credentials = userInfo.split(":");
+            this.password = credentials[1];
+        }
+    }
 
     public HostAndPort getEndpoint() {
         return endpoint;

--- a/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/JedisFactoryTest.java
+++ b/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/JedisFactoryTest.java
@@ -11,9 +11,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import static com.bendb.dropwizard.redis.testing.Subjects.jedisFactory;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assert_;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +33,22 @@ public class JedisFactoryTest {
     public void setup() {
         when(environment.lifecycle()).thenReturn(lifecycleEnvironment);
         factory = new JedisFactory();
+    }
+
+    @Test
+    public void setsEndpointFromUrl() throws MalformedURLException {
+        factory.setUrl(new URL("http://foohost:1234"));
+
+        assert_().about(jedisFactory()).that(factory).hasHost("foohost");
+        assert_().about(jedisFactory()).that(factory).hasPort(1234);
+    }
+
+    @Test
+    public void setsPasswordFromUrl() throws MalformedURLException {
+        factory.setUrl(new URL("http://u:swordfish@foohost:1234"));
+
+        assertEquals("swordfish", factory.getPassword());
+//        assert_().about(jedisFactory()).that(factory).hasPassword("swordfish");
     }
 
     @Test

--- a/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/JedisFactoryTest.java
+++ b/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/JedisFactoryTest.java
@@ -17,7 +17,6 @@ import java.net.URL;
 import static com.bendb.dropwizard.redis.testing.Subjects.jedisFactory;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assert_;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,8 +46,7 @@ public class JedisFactoryTest {
     public void setsPasswordFromUrl() throws MalformedURLException {
         factory.setUrl(new URL("http://u:swordfish@foohost:1234"));
 
-        assertEquals("swordfish", factory.getPassword());
-//        assert_().about(jedisFactory()).that(factory).hasPassword("swordfish");
+        assert_().about(jedisFactory()).that(factory).hasPassword("swordfish");
     }
 
     @Test

--- a/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/testing/JedisFactorySubject.java
+++ b/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/testing/JedisFactorySubject.java
@@ -62,7 +62,7 @@ public class JedisFactorySubject extends Subject<JedisFactorySubject, JedisFacto
         final JedisFactory subject = getSubject();
         if (subject != null) {
             final String password = subject.getPassword();
-            if (password != passwordToCheck) {
+            if (!password.equals(passwordToCheck)) {
                 fail("has proper password");
             }
         } else {


### PR DESCRIPTION
Heroku gives a URL for configuring Redis, this allows using that.

Note my use of `assertEquals()` and commented-out `assert_()` call.  After much trying, I couldn't figure out why that commented-out assertion was failing, and I've no experience with those Google assertions.