### PR TITLE
Fix JooqFactory validation when using Dropwizard 0.9.1.

### DIFF
--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/JooqFactory.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/JooqFactory.java
@@ -1,11 +1,11 @@
 package com.bendb.dropwizard.jooq;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.setup.Environment;
+import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
 import org.jooq.Configuration;
 import org.jooq.ConnectionProvider;
 import org.jooq.DSLContext;
@@ -121,6 +121,7 @@ public class JooqFactory {
     private static final String DEFAULT_NAME = "jooq";
 
     @NotNull
+    @UnwrapValidatedValue(false)
     private Optional<SQLDialect> dialect = Optional.absent();
 
     private boolean logExecutedSql = false;


### PR DESCRIPTION
Dropwizard upgraded their Hibernate Validator version which introduced a change that broke the validation of Optional<> fields in a lot of modules causing the following error message to be printed:

> javax.validation.UnexpectedTypeException: HV000186: The constraint of type 'javax.validation.constraints.NotNull' defined on 'jooq.dialect' has multiple matching constraint validators which is due to an additional value handler of type 'io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapper'. It is unclear which value needs validating. Clarify configuration via @UnwrapValidatedValue.

Adding the annotation required by hibernate fixes this issue.

See also https://github.com/dropwizard/dropwizard/issues/1308 and https://github.com/dropwizard/dropwizard/issues/1292