### PR TITLE
Upgrading to dropwizard 1.2.0

### DIFF
--- a/droptools-example/pom.xml
+++ b/droptools-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>droptools-parent</artifactId>
         <groupId>com.bendb.dropwizard</groupId>
-        <version>1.1.0-1-SNAPSHOT</version>
+        <version>1.2.0-0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dropwizard-jooq/pom.xml
+++ b/dropwizard-jooq/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>droptools-parent</artifactId>
         <groupId>com.bendb.dropwizard</groupId>
-        <version>1.1.0-1-SNAPSHOT</version>
+        <version>1.2.0-0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dropwizard-jooq</artifactId>

--- a/dropwizard-redis/pom.xml
+++ b/dropwizard-redis/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>droptools-parent</artifactId>
         <groupId>com.bendb.dropwizard</groupId>
-        <version>1.1.0-1-SNAPSHOT</version>
+        <version>1.2.0-0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dropwizard-redis</artifactId>

--- a/dropwizard-redis/src/main/java/com/bendb/dropwizard/redis/JedisFactory.java
+++ b/dropwizard-redis/src/main/java/com/bendb/dropwizard/redis/JedisFactory.java
@@ -105,7 +105,7 @@ public class JedisFactory {
     }
 
     public String getHost() {
-        return endpoint.getHostText();
+        return endpoint.getHost();
     }
 
     public int getPort() {

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.bendb.dropwizard</groupId>
     <artifactId>droptools-parent</artifactId>
-    <version>1.1.0-1-SNAPSHOT</version>
+    <version>1.2.0-0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -55,7 +55,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>1.1.0</dropwizard.version>
+        <dropwizard.version>1.2.0</dropwizard.version>
         <coberatura.version>2.7</coberatura.version>
 
         <github.global.server>github</github.global.server>


### PR DESCRIPTION
Hi,

I didn't try to get the `droptools-example` running because it assumes some postgres sql running that I don't have (plus, it has a maven property set to DW v1.0.0 even though the rest of the libraries are DW v1.1.0 so I'm not sure if you still use/care about the examples), but the 2 libraries compile and tests pass fine.