### PR TITLE
Use configured timeout value as the time to wait for a connection from the pool.

### DIFF
--- a/dropwizard-redis/src/main/java/com/bendb/dropwizard/redis/JedisFactory.java
+++ b/dropwizard-redis/src/main/java/com/bendb/dropwizard/redis/JedisFactory.java
@@ -164,6 +164,7 @@ public class JedisFactory {
         poolConfig.setMinIdle(getMinIdle());
         poolConfig.setMaxIdle(getMaxIdle());
         poolConfig.setMaxTotal(getMaxTotal());
+        poolConfig.setMaxWaitMillis(getTimeout()); // Use configured timeout value as the time to wait for a connection
 
         final JedisPool pool = new JedisPool(poolConfig, getHost(), getPort(), getTimeout(), getPassword(), ssl);
 


### PR DESCRIPTION
This is a solution for Issue #52 