### PR TITLE
Replace master/slave with primary/replica

### DIFF
--- a/droptools-example/config/dev.yml
+++ b/droptools-example/config/dev.yml
@@ -24,7 +24,7 @@ logging:
     - type: console
       target: stdout
 
-databaseMaster:
+databasePrimary:
   driverClass: org.postgresql.Driver
   user: example_user
   password: s3cr3t
@@ -32,7 +32,7 @@ databaseMaster:
 
 # In this example the follower connects to the same DB as the
 # leader, but this could just as simply be a replica
-databaseSlave:
+databaseReplica:
   driverClass: org.postgresql.Driver
   user: example_user
   password: s3cr3t

--- a/droptools-example/src/main/java/com/bendb/example/ExampleApp.java
+++ b/droptools-example/src/main/java/com/bendb/example/ExampleApp.java
@@ -22,7 +22,7 @@ public class ExampleApp extends Application<ExampleConfig> {
         bootstrap.addBundle(new FlywayBundle<ExampleConfig>() {
             @Override
             public DataSourceFactory getDataSourceFactory(ExampleConfig configuration) {
-                return configuration.dataSourceFactoryMaster();
+                return configuration.dataSourceFactoryPrimary();
             }
 
             @Override
@@ -38,7 +38,7 @@ public class ExampleApp extends Application<ExampleConfig> {
              */
             @Override
             public DataSourceFactory getDataSourceFactory(ExampleConfig configuration) {
-                return configuration.dataSourceFactoryMaster();
+                return configuration.dataSourceFactoryPrimary();
             }
 
             /**
@@ -48,7 +48,7 @@ public class ExampleApp extends Application<ExampleConfig> {
             public SortedMap<String,DataSourceFactory> getSecondaryDataSourceFactories(ExampleConfig configuration) {
                 // override this method to define database configurations
                 final SortedMap<String,DataSourceFactory> dataSourceFactoryMap = new TreeMap<>();
-                dataSourceFactoryMap.put("slave", configuration.dataSourceFactorySlave());
+                dataSourceFactoryMap.put("replica", configuration.dataSourceFactoryReplica());
                 return dataSourceFactoryMap;
             }
 
@@ -58,7 +58,7 @@ public class ExampleApp extends Application<ExampleConfig> {
              */
             @Override
             public String primaryDataSourceName() {
-                return "master";
+                return "primary";
             }
 
             @Override

--- a/droptools-example/src/main/java/com/bendb/example/ExampleConfig.java
+++ b/droptools-example/src/main/java/com/bendb/example/ExampleConfig.java
@@ -19,11 +19,11 @@ public class ExampleConfig extends Configuration {
 
     @JsonProperty
     @NotNull
-    private DataSourceFactory databaseMaster;
+    private DataSourceFactory databasePrimary;
 
     @JsonProperty
     @NotNull
-    private DataSourceFactory databaseSlave;
+    private DataSourceFactory databaseReplica;
 
     public FlywayFactory flyway() {
         return flyway;
@@ -33,11 +33,11 @@ public class ExampleConfig extends Configuration {
         return jooq;
     }
 
-    public DataSourceFactory dataSourceFactoryMaster() {
-        return databaseMaster;
+    public DataSourceFactory dataSourceFactoryPrimary() {
+        return databasePrimary;
     }
 
-    public DataSourceFactory dataSourceFactorySlave() {
-        return databaseSlave;
+    public DataSourceFactory dataSourceFactoryReplica() {
+        return databaseReplica;
     }
 }

--- a/droptools-example/src/main/java/com/bendb/example/resources/PostsResource.java
+++ b/droptools-example/src/main/java/com/bendb/example/resources/PostsResource.java
@@ -27,11 +27,11 @@ import static org.jooq.impl.DSL.*;
 public class PostsResource {
 
     @GET
-    public List<BlogPost> findPostsByTag(@QueryParam("tag") String tag, @JooqInject("slave") DSLContext slave) {
+    public List<BlogPost> findPostsByTag(@QueryParam("tag") String tag, @JooqInject("replica") DSLContext db) {
         final PostTag pt = POST_TAG.as("pt");
 
         // Try *that* in JPA
-        return slave.with("postIds").as(
+        return db.with("postIds").as(
                     select(POST_TAG.POST_ID.as("id"))
                         .from(POST_TAG)
                         .where(POST_TAG.TAG_NAME.equal(DSL.lower(tag))))
@@ -62,9 +62,9 @@ public class PostsResource {
     public Response createPost(
             final @FormParam("text") String text,
             final @FormParam("tags") List<String> tags,
-            @JooqInject("master") DSLContext master) {
+            @JooqInject("primary") DSLContext db) {
         // TODO(ben): implement something like @UnitOfWork
-        return master.transactionResult(new TransactionalCallable<Response>() {
+        return db.transactionResult(new TransactionalCallable<Response>() {
             @Override
             public Response run(Configuration configuration) throws Exception {
                 DSLContext cxt = DSL.using(configuration);


### PR DESCRIPTION
I felt privately uncomfortable when, years ago, these names were used in the multi-datasource PR.  As I recall it was already a somewhat-contentious PR and I didn't feel up to requesting the change.  With the benefit of hindsight, I see that I should have.

It's my repo, and I feel good about replacing the "master/slave" labels with "primary/replica".