### PR TITLE
Update Dropwizard to 2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ allprojects {
     version VERSION
 
     project.ext {
-        dropwizardVersion = "1.3.12"
+        dropwizardVersion = "2.0.0"
         jooqVersion = "3.11.11"
         jedisVersion = "3.0.1"
 

--- a/droptools-example/src/main/java/com/bendb/example/resources/PostsResource.java
+++ b/droptools-example/src/main/java/com/bendb/example/resources/PostsResource.java
@@ -26,6 +26,10 @@ import static org.jooq.impl.DSL.*;
 @Produces(MediaType.APPLICATION_JSON)
 public class PostsResource {
 
+    @Context
+    @JooqInject("primary")
+    DSLContext primary;
+
     @GET
     public List<BlogPost> findPostsByTag(@QueryParam("tag") String tag, @JooqInject("replica") DSLContext db) {
         final PostTag pt = POST_TAG.as("pt");
@@ -61,10 +65,9 @@ public class PostsResource {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     public Response createPost(
             final @FormParam("text") String text,
-            final @FormParam("tags") List<String> tags,
-            @JooqInject("primary") DSLContext db) {
+            final @FormParam("tags") List<String> tags) {
         // TODO(ben): implement something like @UnitOfWork
-        return db.transactionResult(new TransactionalCallable<Response>() {
+        return primary.transactionResult(new TransactionalCallable<Response>() {
             @Override
             public Response run(Configuration configuration) throws Exception {
                 DSLContext cxt = DSL.using(configuration);

--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/JooqFactory.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/JooqFactory.java
@@ -5,22 +5,19 @@ import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.setup.Environment;
-import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
 import org.jooq.Configuration;
 import org.jooq.ConnectionProvider;
-import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
-import org.jooq.conf.*;
-import org.jooq.impl.DSL;
+import org.jooq.conf.ParamType;
+import org.jooq.conf.RenderKeywordStyle;
+import org.jooq.conf.RenderNameStyle;
+import org.jooq.conf.Settings;
+import org.jooq.conf.StatementType;
 import org.jooq.impl.DataSourceConnectionProvider;
 import org.jooq.impl.DefaultConfiguration;
-import org.jooq.impl.DefaultExecuteListenerProvider;
 import org.jooq.tools.jdbc.JDBCUtils;
 
 import javax.validation.constraints.NotNull;
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.SQLException;
 
 /**
  * A factory for jOOQ {@link org.jooq.Configuration} objects.
@@ -124,7 +121,6 @@ public class JooqFactory {
     private static final String DEFAULT_NAME = "jooq";
 
     @NotNull
-    @UnwrapValidatedValue(false)
     private Optional<SQLDialect> dialect = Optional.absent();
 
     private boolean renderSchema = true;

--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/jersey/DSLContextFeature.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/jersey/DSLContextFeature.java
@@ -1,0 +1,23 @@
+package com.bendb.dropwizard.jooq.jersey;
+
+import com.google.common.base.Preconditions;
+import org.jooq.Configuration;
+
+import javax.annotation.Nonnull;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import java.util.SortedMap;
+
+public class DSLContextFeature implements Feature {
+    private final SortedMap<String, Configuration> configurations;
+
+    public DSLContextFeature(@Nonnull SortedMap<String, Configuration> configurations) {
+        this.configurations = Preconditions.checkNotNull(configurations, "configurations");
+    }
+
+    @Override
+    public boolean configure(FeatureContext context) {
+        context.register(new JooqBinder(configurations));
+        return true;
+    }
+}

--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/jersey/DSLContextValueParamProvider.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/jersey/DSLContextValueParamProvider.java
@@ -1,40 +1,41 @@
 package com.bendb.dropwizard.jooq.jersey;
 
-import org.glassfish.hk2.api.Factory;
+import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.model.Parameter;
-import org.glassfish.jersey.server.spi.internal.ValueFactoryProvider;
+import org.glassfish.jersey.server.spi.internal.ValueParamProvider;
 import org.jooq.Configuration;
 import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+
 import javax.inject.Singleton;
 import java.util.Map;
+import java.util.function.Function;
 
 @Singleton
-public final class DSLContextValueFactoryProvider implements ValueFactoryProvider {
+public final class DSLContextValueParamProvider implements ValueParamProvider {
 
     final Map<String, Configuration> configurationMap;
 
-    public DSLContextValueFactoryProvider(Map<String, Configuration> configurationMap) {
+    public DSLContextValueParamProvider(Map<String, Configuration> configurationMap) {
         this.configurationMap = configurationMap;
     }
 
     @Override
-    public Factory<?> getValueFactory(Parameter parameter) {
+    public Function<ContainerRequest, ?> getValueProvider(Parameter parameter) {
         final Class<?> classType = parameter.getRawType();
         final JooqInject jooqInjectParam = parameter.getAnnotation(JooqInject.class);
 
         return (classType == null || !classType.equals(DSLContext.class) || jooqInjectParam == null)
-               ? null // return null when parameter not supported
-               : new DSLContextFactory(getConfiguration(configurationMap, jooqInjectParam.value())
-               );
+                ? null // return null when parameter not supported
+                : (req) -> DSL.using(getConfiguration(jooqInjectParam.value()));
     }
 
     @Override
     public PriorityType getPriority() {
-        return ValueFactoryProvider.Priority.NORMAL;
+        return ValueParamProvider.Priority.NORMAL;
     }
 
     private Configuration getConfiguration(
-            final Map<String, Configuration> configurationMap,
             final String key
     ) {
         return (configurationMap.containsKey(key))

--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/jersey/JooqBinder.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/jersey/JooqBinder.java
@@ -2,11 +2,11 @@ package com.bendb.dropwizard.jooq.jersey;
 
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
-import org.glassfish.jersey.server.spi.internal.ValueFactoryProvider;
+import org.glassfish.jersey.server.spi.internal.ValueParamProvider;
 import org.jooq.Configuration;
 import org.jooq.ConnectionProvider;
 import org.jooq.DSLContext;
-import java.util.Map;
+
 import java.util.SortedMap;
 
 /**
@@ -38,8 +38,8 @@ public class JooqBinder extends AbstractBinder {
                     .to(ConnectionProvider.class);
         }
 
-        // bind a ValueFactoryProvider for Named DSLContext(s)
-        bind(new DSLContextValueFactoryProvider(configurationMap))
-                .to(ValueFactoryProvider.class);
+        // bind a ValueParamProvider for Named DSLContext(s)
+        bind(new DSLContextValueParamProvider(configurationMap))
+                .to(ValueParamProvider.class);
     }
 }

--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/jersey/JooqInject.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/jersey/JooqInject.java
@@ -2,7 +2,7 @@ package com.bendb.dropwizard.jooq.jersey;
 
 import java.lang.annotation.*;
 
-@Target({ElementType.PARAMETER})
+@Target({ElementType.PARAMETER, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface JooqInject {

--- a/dropwizard-jooq/src/test/java/com/bendb/dropwizard/jooq/JooqBundleTest.java
+++ b/dropwizard-jooq/src/test/java/com/bendb/dropwizard/jooq/JooqBundleTest.java
@@ -14,6 +14,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -82,8 +83,8 @@ public class JooqBundleTest {
         when(jooqFactory.build(environment, dataSourceFactoryPrimary, DEFAULT_NAME)).thenReturn(jooqConfigPrimary);
         when(jooqFactory.build(environment, dataSourceFactoryPrimary, DATASOURCE_PRIMARY)).thenReturn(jooqConfigPrimary);
         when(jooqFactory.build(environment, dataSourceFactoryReplica, DATASOURCE_REPLICA)).thenReturn(jooqConfigReplica);
-        when(dataSourceFactoryPrimary.getValidationQuery()).thenReturn(validationQueryPrimary);
-        when(dataSourceFactoryReplica.getValidationQuery()).thenReturn(validationQueryReplica);
+        when(dataSourceFactoryPrimary.getValidationQuery()).thenReturn(Optional.ofNullable(validationQueryPrimary));
+        when(dataSourceFactoryReplica.getValidationQuery()).thenReturn(Optional.ofNullable(validationQueryReplica));
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.bendb.dropwizard
-VERSION=1.3.12-0-SNAPSHOT
+VERSION=2.0.0-0-SNAPSHOT
 
 POM_URL=https://github.com/benjamin-bader/droptools/
 


### PR DESCRIPTION
Moderate changes in dropwizard-jooq to accommodate the changes in Jersey's param-injection APIs, but mostly the same.

It's now a little nicer for Jooq users - with this PR you can do `@Context` field injection, too.