### PR TITLE
Modernize Gradle project, fix tests

### DIFF
--- a/build-src/build.gradle
+++ b/build-src/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id "java-gradle-plugin"
+}
+
+gradlePlugin {
+    plugins {
+        java {
+            id = "droptools-java-library"
+            displayName = "Droptools Java Library"
+            description = "Common Java library settings for Droptools modules"
+            implementationClass = "com.bendb.droptools.gradle.DroptoolsJavaPlugin"
+        }
+    }
+}

--- a/build-src/settings.gradle
+++ b/build-src/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/build-src/src/main/java/com/bendb/droptools/gradle/DroptoolsJavaPlugin.java
+++ b/build-src/src/main/java/com/bendb/droptools/gradle/DroptoolsJavaPlugin.java
@@ -1,0 +1,57 @@
+package com.bendb.droptools.gradle;
+
+import java.util.Objects;
+import org.gradle.api.JavaVersion;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaLibraryPlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.plugins.PluginContainer;
+import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.testing.Test;
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat;
+import org.gradle.api.tasks.testing.logging.TestLogEvent;
+import org.gradle.plugins.ide.idea.IdeaPlugin;
+import org.jetbrains.annotations.NotNull;
+
+public class DroptoolsJavaPlugin implements Plugin<Project> {
+
+  @Override
+  public void apply(@NotNull Project p) {
+    applyBasePlugins(p.getPlugins());
+
+    p.setGroup(Objects.requireNonNull(p.findProperty("GROUP")));
+    p.setVersion(Objects.requireNonNull(p.findProperty("VERSION")));
+
+    applyJavaSettings(p);
+    configureTestTasks(p);
+  }
+
+  private static void applyBasePlugins(PluginContainer plugins) {
+    plugins.apply(JavaLibraryPlugin.class);
+    plugins.apply(IdeaPlugin.class);
+  }
+
+  private static void applyJavaSettings(Project p) {
+    var settings = Objects.requireNonNull(p.getExtensions().findByType(JavaPluginExtension.class));
+    settings.setSourceCompatibility(JavaVersion.VERSION_11);
+    settings.setTargetCompatibility(JavaVersion.VERSION_11);
+
+    p.getTasks().withType(JavaCompile.class).configureEach(t -> {
+      t.getOptions().setFork(true);
+      t.getOptions().setIncremental(true);
+    });
+  }
+
+  private static void configureTestTasks(Project p) {
+    p.getTasks().withType(Test.class).configureEach(task -> {
+      task.testLogging(logging -> {
+        logging.events(TestLogEvent.FAILED);
+        logging.setShowExceptions(true);
+        logging.setShowStackTraces(true);
+        logging.setShowCauses(true);
+        logging.setExceptionFormat(TestExceptionFormat.FULL);
+      });
+    });
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,85 +1,21 @@
-allprojects {
-    repositories {
-        mavenCentral()
-    }
-
-    group GROUP
-    version VERSION
-
-    project.ext {
-        dropwizardVersion = "3.0.0"
-        jooqVersion = "3.16.18"
-        jedisVersion = "3.0.1"
-        postgresPluginVersion = "42.6.0"
-
-        libs = [
-            testing: [
-                "junit:junit:4.12",
-                "org.mockito:mockito-all:1.10.19",
-                "com.google.truth:truth:1.1.3",
-            ],
-
-            dropwizardDb: "io.dropwizard:dropwizard-db:$dropwizardVersion",
-            jooq: "org.jooq:jooq:$jooqVersion",
-
-            dropwizardCore: "io.dropwizard:dropwizard-core:$dropwizardVersion",
-            jedis: "redis.clients:jedis:$jedisVersion",
-        ]
-    }
+plugins {
+    id "droptools-java-library" apply false
+    id "jacoco"
 }
 
-buildscript {
-    repositories {
-        mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-}
-
-subprojects { sp ->
-    apply plugin: "java-library"
-    apply plugin: "idea"
-    apply plugin: "jacoco"
-
-    sourceCompatibility = "11"
-    targetCompatibility = "11"
-
-    tasks.withType(JavaCompile) {
-        options.fork = true
-        options.incremental = true
-    }
-
-    test {
-        testLogging {
-            events "failed"
-            exceptionFormat "full"
-            showStackTraces true
-            showExceptions true
-            showCauses true
-        }
-    }
-}
-
-apply plugin: "jacoco"
-
-task codeCoverageReport(type: JacocoReport) {
-    executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
+tasks.register("codeCoverageReport", JacocoReport) { t ->
+    t.executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
 
     subprojects.each {
+        t.dependsOn it.tasks.withType(Test)
         sourceSets it.sourceSets.main
     }
 
-    reports {
+    t.reports {
         xml.destination file("$buildDir/reports/jacoco/report.xml")
     }
 }
 
-codeCoverageReport.dependsOn {
-    [subprojects*.test, ':droptools-example:startScripts', ':droptools-example:startShadowScripts']
-}
-
-// To accept gradle scans and publish them
 if (hasProperty('buildScan')) {
     buildScan {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'

--- a/droptools-example/build.gradle
+++ b/droptools-example/build.gradle
@@ -1,23 +1,11 @@
-buildscript {
-    repositories {
-        mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-
-    dependencies {
-        classpath "nu.studer:gradle-jooq-plugin:8.2"
-        classpath "com.github.johnrengelman:shadow:8.1.1"
-    }
+plugins {
+    id "application"
+    alias libs.plugins.jooq
+    alias libs.plugins.shadow
 }
 
 group = "com.bendb.droptools"
 description = "blah"
-
-apply plugin: "application"
-apply plugin: "nu.studer.jooq"
-apply plugin: "com.github.johnrengelman.shadow"
 
 tasks.withType(PublishToMavenRepository).configureEach { it.enabled = false }
 
@@ -35,27 +23,29 @@ shadowJar {
 dependencies {
     implementation project(":dropwizard-jooq")
 
-    implementation libs.dropwizardCore
-    implementation libs.dropwizardDb
-    implementation "io.dropwizard.modules:dropwizard-flyway:3.0.0-1"
+    implementation libs.dropwizard.core
+    implementation libs.dropwizard.db
+    implementation libs.dropwizard.flyway
 
-    implementation "com.google.auto.value:auto-value-annotations:1.10.1"
-    annotationProcessor "com.google.auto.value:auto-value:1.10.1"
+    implementation libs.autovalue.annotations
+    annotationProcessor libs.autovalue.processor
 
-    implementation "org.postgresql:postgresql:$postgresPluginVersion"
+    implementation libs.postgres
 
     // For jOOQ
-    jooqGenerator group: "org.postgresql", name: "postgresql", version: "$postgresPluginVersion"
+    jooqGenerator libs.postgres
 }
 
 jooq {
-    version = jooqVersion // Leaving this in, because we can change the jOOQ version
+    version = libs.versions.jooq.get() // Leaving this in, because we can change the jOOQ version
 
     configurations {
         main {  // name of the jOOQ configuration
-            generateSchemaSourceOnCompilation = true  // default (can be omitted)
+            generateSchemaSourceOnCompilation = false
 
             generationTool {
+                logging = org.jooq.meta.jaxb.Logging.DEBUG
+
                 jdbc {
                     driver = 'org.postgresql.Driver'
                     url = "jdbc:postgresql://localhost:5432/example_app"
@@ -65,20 +55,8 @@ jooq {
                 generator {
                     name = 'org.jooq.codegen.DefaultGenerator'
                     database {
-                        name = 'org.jooq.meta.postgres.PostgresDatabase'
-                        inputSchema = 'ex'
-                        forcedTypes {
-                            forcedType {
-                                name = 'varchar'
-                                includeExpression = '.*'
-                                includeTypes = 'JSONB?'
-                            }
-                            forcedType {
-                                name = 'varchar'
-                                includeExpression = '.*'
-                                includeTypes = 'INET'
-                            }
-                        }
+                        name = "org.jooq.meta.postgres.PostgresDatabase"
+                        inputSchema = "ex"
                     }
                     generate {
                         deprecated = false
@@ -87,9 +65,8 @@ jooq {
                         fluentSetters = true
                     }
                     target {
-                        packageName = 'com.bendb.example.db'
+                        packageName = "com.bendb.example.db"
                     }
-                    strategy.name = 'org.jooq.codegen.DefaultGeneratorStrategy'
                 }
             }
         }

--- a/dropwizard-jooq/build.gradle
+++ b/dropwizard-jooq/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "droptools-java-library"
     id "com.github.ben-manes.versions" version "0.46.0"
 }
 
@@ -6,9 +7,9 @@ description = "Addon bundle for Dropwizard to support jOOQ for database access"
 
 dependencies {
     api libs.jooq
-    implementation libs.dropwizardDb
-    implementation libs.dropwizardCore
+    implementation libs.dropwizard.core
+    implementation libs.dropwizard.db
 
-    testImplementation libs.testing
+    testImplementation libs.bundles.testing
 }
 

--- a/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/JooqFactory.java
+++ b/dropwizard-jooq/src/main/java/com/bendb/dropwizard/jooq/JooqFactory.java
@@ -263,7 +263,7 @@ public class JooqFactory {
         this.fetchWarnings = fetchWarnings;
     }
 
-    public Configuration build(Environment environment, DataSourceFactory factory) throws ClassNotFoundException {
+    public Configuration build(Environment environment, PooledDataSourceFactory factory) throws ClassNotFoundException {
         return build(environment, factory, DEFAULT_NAME);
     }
 

--- a/dropwizard-jooq/src/test/java/com/bendb/dropwizard/jooq/JooqBundleTest.java
+++ b/dropwizard-jooq/src/test/java/com/bendb/dropwizard/jooq/JooqBundleTest.java
@@ -1,5 +1,6 @@
 package com.bendb.dropwizard.jooq;
 
+import com.bendb.dropwizard.jooq.jersey.DSLContextFeature;
 import com.bendb.dropwizard.jooq.jersey.JooqBinder;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import io.dropwizard.db.DataSourceFactory;
@@ -12,14 +13,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -97,15 +97,14 @@ public class JooqBundleTest {
     @Test
     public void doesNothingInBootstrap() {
         jooqBundle.initialize(bootstrap);
-        verifyZeroInteractions(bootstrap);
+        verifyNoInteractions(bootstrap);
     }
 
     @Test
     public void registersAnInjectibleProviderOnParameters() throws Exception {
         jooqBundle.run(new DropwizardConfig(), environment);
 
-        ArgumentCaptor<JooqBinder> captor = ArgumentCaptor.forClass(JooqBinder.class);
-        verify(jerseyEnvironment, atLeastOnce()).register(captor.capture());
+        verify(jerseyEnvironment, atLeastOnce()).register(isA(DSLContextFeature.class));
     }
 
     @Test

--- a/dropwizard-jooq/src/test/java/com/bendb/dropwizard/jooq/JooqFactoryTest.java
+++ b/dropwizard-jooq/src/test/java/com/bendb/dropwizard/jooq/JooqFactoryTest.java
@@ -1,33 +1,35 @@
 package com.bendb.dropwizard.jooq;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
-import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.db.ManagedDataSource;
-import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.core.setup.Environment;
+import io.dropwizard.db.ManagedDataSource;
+import io.dropwizard.db.PooledDataSourceFactory;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import org.jooq.Configuration;
-import org.jooq.ExecuteListener;
-import org.jooq.ExecuteListenerProvider;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DataSourceConnectionProvider;
-import org.jooq.impl.DefaultExecuteListenerProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JooqFactoryTest {
-    @Mock DataSourceFactory dataSourceFactory;
+    @Mock PooledDataSourceFactory dataSourceFactory;
     @Mock ManagedDataSource managedDataSource;
     @Mock Environment environment;
     @Mock LifecycleEnvironment lifecycle;
+    @Mock MetricRegistry metricRegistry;
     final static String DATASOURCE_NAME = "database";
 
     private JooqFactory factory;
@@ -35,6 +37,7 @@ public class JooqFactoryTest {
     @Before
     public void setup() throws Exception {
         when(environment.lifecycle()).thenReturn(lifecycle);
+        when(environment.metrics()).thenReturn(metricRegistry);
         when(dataSourceFactory.build(any(MetricRegistry.class), anyString())).thenReturn(managedDataSource);
 
         factory = new JooqFactory();
@@ -57,7 +60,7 @@ public class JooqFactoryTest {
 
     @Test
     public void infersDialectFromJdbcUrlWhenDialectIsNotSpecified() throws Exception {
-        when(dataSourceFactory.getUrl()).thenReturn("jdbc:postgresql://localhost:5432/test");
+        doReturn("jdbc:postgresql://localhost:5432/test").when(dataSourceFactory).getUrl();
 
         factory.setDialect(Optional.<SQLDialect>absent());
         Configuration config = factory.build(environment, dataSourceFactory);
@@ -66,7 +69,7 @@ public class JooqFactoryTest {
 
     @Test
     public void usesSpecifiedDialect() throws Exception {
-        when(dataSourceFactory.getUrl()).thenReturn("jdbc:postgresql://localhost:5432/test");
+        lenient().doReturn("jdbc:postgresql://localhost:5432/test").when(dataSourceFactory).getUrl();
 
         factory.setDialect(Optional.of(SQLDialect.DERBY));
         Configuration config = factory.build(environment, dataSourceFactory);

--- a/dropwizard-jooq/src/test/java/com/bendb/dropwizard/jooq/jersey/LoggingDataAccessExceptionMapperTest.java
+++ b/dropwizard-jooq/src/test/java/com/bendb/dropwizard/jooq/jersey/LoggingDataAccessExceptionMapperTest.java
@@ -6,13 +6,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 
 import java.sql.SQLException;
 
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/dropwizard-redis/build.gradle
+++ b/dropwizard-redis/build.gradle
@@ -1,9 +1,13 @@
+plugins {
+    id "droptools-java-library"
+}
+
 description = "Addon bundle for Dropwizard to support use of Redis"
 
 dependencies {
     api libs.jedis
-    implementation libs.dropwizardCore
+    implementation libs.dropwizard.core
 
-    testImplementation libs.testing
+    testImplementation libs.bundles.testing
 }
 

--- a/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/JedisBundleTest.java
+++ b/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/JedisBundleTest.java
@@ -1,5 +1,6 @@
 package com.bendb.dropwizard.redis;
 
+import com.bendb.dropwizard.redis.jersey.JedisPoolBinder;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
@@ -14,11 +15,10 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import redis.clients.jedis.JedisPool;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -46,21 +46,21 @@ public class JedisBundleTest {
             }
         };
 
-        when(environment.healthChecks()).thenReturn(healthChecks);
-        when(environment.jersey()).thenReturn(jerseyEnvironment);
-        when(environment.lifecycle()).thenReturn(lifecycleEnvironment);
-        when(environment.metrics()).thenReturn(metricRegistry);
+        lenient().when(environment.healthChecks()).thenReturn(healthChecks);
+        lenient().when(environment.jersey()).thenReturn(jerseyEnvironment);
+        lenient().when(environment.lifecycle()).thenReturn(lifecycleEnvironment);
+        lenient().when(environment.metrics()).thenReturn(metricRegistry);
 
-        when(jedisFactory.build(environment)).thenReturn(pool);
-        when(pool.getNumActive()).thenReturn(10);
-        when(pool.getNumIdle()).thenReturn(5);
-        when(pool.getNumWaiters()).thenReturn(1);
+        lenient().when(jedisFactory.build(environment)).thenReturn(pool);
+        lenient().when(pool.getNumActive()).thenReturn(10);
+        lenient().when(pool.getNumIdle()).thenReturn(5);
+        lenient().when(pool.getNumWaiters()).thenReturn(1);
     }
 
     @Test
     public void bootstrapsNothing() throws Exception {
         bundle.initialize(bootstrap);
-        verifyZeroInteractions(bootstrap);
+        verifyNoInteractions(bootstrap);
     }
 
     @Test
@@ -85,9 +85,6 @@ public class JedisBundleTest {
     public void registersJedisInjectableProvider() throws Exception {
         bundle.run(config, environment);
 
-        ArgumentCaptor<JedisFactory> captor = ArgumentCaptor.forClass(JedisFactory.class);
-        verify(jerseyEnvironment, atLeastOnce()).register(captor.capture());
-
-        assertThat(captor.getValue()).isNotNull();
+        verify(jerseyEnvironment, atLeastOnce()).register(isA(JedisPoolBinder.class));
     }
 }

--- a/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/JedisFactoryTest.java
+++ b/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/JedisFactoryTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.net.URI;
 

--- a/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/JedisHealthCheckTest.java
+++ b/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/JedisHealthCheckTest.java
@@ -4,7 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.exceptions.JedisConnectionException;

--- a/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/JedisPoolManagerTest.java
+++ b/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/JedisPoolManagerTest.java
@@ -5,7 +5,7 @@ import redis.clients.jedis.JedisPool;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 public class JedisPoolManagerTest {
     @Test
@@ -22,6 +22,6 @@ public class JedisPoolManagerTest {
     public void doesNothingOnStart() throws Exception {
         JedisPool pool = mock(JedisPool.class);
         new JedisPoolManager(pool).start();
-        verifyZeroInteractions(pool);
+        verifyNoInteractions(pool);
     }
 }

--- a/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/jersey/JedisFactoryTest.java
+++ b/dropwizard-redis/src/test/java/com/bendb/dropwizard/redis/jersey/JedisFactoryTest.java
@@ -4,7 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,29 @@
+[versions]
+autoValue = "1.10.1"
+dropwizard = "3.0.0"
+jooq = "3.16.18"
+jedis = "3.0.1"
+postgres = "42.6.0"
+
+[libraries]
+autovalue-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "autoValue" }
+autovalue-processor = { module = "com.google.auto.value:auto-value", version.ref = "autoValue" }
+dropwizard-core = { module = "io.dropwizard:dropwizard-core", version.ref = "dropwizard" }
+dropwizard-db = { module = "io.dropwizard:dropwizard-db", version.ref = "dropwizard" }
+dropwizard-flyway = "io.dropwizard.modules:dropwizard-flyway:3.0.0-1"
+jedis = { module = "redis.clients:jedis", version.ref = "jedis" }
+jooq = { module = "org.jooq:jooq", version.ref = "jooq" }
+postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
+
+
+# test deps
+junit = "junit:junit:4.12"
+mockito = "org.mockito:mockito-core:5.3.1"
+truth = "com.google.truth:truth:1.1.3"
+
+[plugins]
+jooq = "nu.studer.jooq:7.2"
+shadow = "com.github.johnrengelman.shadow:8.1.1"
+
+[bundles]
+testing = ["junit", "mockito", "truth"]

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,24 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.PREFER_SETTINGS
+
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+includeBuild "build-src"
+
 rootProject.name = "droptools"
 include "dropwizard-jooq"
 include "dropwizard-redis"
 include "droptools-example"
-


### PR DESCRIPTION
This started as an effort to standardize on my current preferred Gradle project setup:
- version catalog to centralize dependencies
- included build to centralize common setup (no more subprojects*/allprojects)
- manage repositories globally in settings.gradle

On the way, I discovered that tests were broken pretty badly.  We missed it because apparently our CI runner isn't working - will need to fix that.

- mockito 1 doesn't work on Java 11, so updated to the latest
- lots of import errors, easy enough to fix
- lots of errors about unnecessary stubbing - mostly fixed by using `lenient()`
- apparently the DW upgrade carries some internal changes that we used to rely on in tests (eager evaluation of bindings or features on registration); those weren't very good tests, so I mostly made them less-specific

Next up, Github Actions for CI.  Then removing Guava Optionals.